### PR TITLE
fix(render): 修复非整数 DPI 下文字最后一字误换行

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -74,13 +74,18 @@ impl Rect {
     pub fn is_empty(&self) -> bool {
         self.w <= 0 || self.h <= 0
     }
-    /// 按缩放因子转为物理像素矩形。按边界（右/下）取整，避免四分量独立 round 漂移。
+    /// 按缩放因子转为物理像素矩形。
+    ///
+    /// 左/上边向下取整（`floor`），右/下边向上取整（`ceil`），保证物理矩形
+    /// 的宽高**不小于** `size × scale`——避免因取整导致测量阶段预留的逻辑宽度
+    /// 在绘制阶段反向换算后被截短，进而使本应单行的文字最后一个字换到下一行。
+    /// 这个差异在 125%/175%/225% 等非整数 DPI 下尤其显著。
     pub fn scaled(&self, s: f32) -> Rect {
-        let x0 = (self.x as f32 * s).round() as i32;
-        let y0 = (self.y as f32 * s).round() as i32;
-        let x1 = (self.right() as f32 * s).round() as i32;
-        let y1 = (self.bottom() as f32 * s).round() as i32;
-        Rect::new(x0, y0, x1 - x0, y1 - y0)
+        let x0 = (self.x as f32 * s).floor() as i32;
+        let y0 = (self.y as f32 * s).floor() as i32;
+        let x1 = (self.right() as f32 * s).ceil() as i32;
+        let y1 = (self.bottom() as f32 * s).ceil() as i32;
+        Rect::new(x0, y0, (x1 - x0).max(0), (y1 - y0).max(0))
     }
 
     /// 包含两矩形的最小外接矩形（空矩形被忽略）。

--- a/src/text/dwrite.rs
+++ b/src/text/dwrite.rs
@@ -323,8 +323,11 @@ impl TextEngine for DWriteEngine {
         let prect = rect.scaled(s);
         let pclip = clip.map(|c| c.scaled(s));
         let psize = size * s;
-        // 按物理 rect 宽度换行（与 measure 传入的物理 maxWidth 一致）。
-        let Some(layout) = self.layout(text, ts, psize, prect.w as f32) else {
+        // 用 rect.w * s（精确乘法，与 measure 里 pmw = max_width * s 同源）作为
+        // 排版最大宽度。prect.w 是经 scaled() 取整后的物理宽度，可能因取整略小于
+        // rect.w * s，导致本应单行的文字被截断换行（125%/175% 等非整数 DPI 典型）。
+        let layout_max_w = (rect.w as f32 * s).max(prect.w as f32);
+        let Some(layout) = self.layout(text, ts, psize, layout_max_w) else {
             return;
         };
         let mut m = DWRITE_TEXT_METRICS::default();


### PR DESCRIPTION
Rect::scaled() 原用 round() 对四条边独立取整后以 x1-x0 计算物理宽高， 可能在取整方向不一致时使物理宽度略小于 width×scale。measure 阶段
用 ceil(physical/scale) 得到逻辑宽度，而 draw 阶段反向换算后物理
宽度不足，DirectWrite/CoreText 因此在 125%/175%/225% 等奇数倍 25% DPI 下将本应单行的文字最后一字错误换到下一行。

修复：
- geometry: scaled() 左/上改用 floor()、右/下改用 ceil()，保证 物理矩形宽高始终 ≥ size×scale。
- dwrite: draw() 排版宽度改为 rect.w×scale（精确乘法，与 measure 同源），避免依赖取整后的 prect.w。

<!-- 感谢贡献！请填写以下信息。Thanks for contributing! Please fill in the following. -->

## 动机 / Motivation
<!-- 为什么需要这个改动？关联 issue：Closes #xxx -->
关联 issue：Closes #6 
## 改动内容 / What changed
- geometry: scaled() 左/上改用 floor()、右/下改用 ceil()，保证 物理矩形宽高始终 ≥ size×scale。
- dwrite: draw() 排版宽度改为 rect.w×scale（精确乘法，与 measure 同源），避免依赖取整后的 prect.w。
- 
## 如何验证 / How to verify
将系统缩放比例调整到25%奇数倍，观察是否有不该换行的文字换行了。
修改前
<img width="2099" height="860" alt="Image" src="https://github.com/user-attachments/assets/e95e3ad2-e353-4a93-9541-151dfc6ad182" />
修改后
<img width="2369" height="635" alt="image" src="https://github.com/user-attachments/assets/4a64b696-1cde-45be-8a13-ca2a7e590acb" />

## 检查清单 / Checklist
- [x] `cargo build --all-targets` 通过
- [x] `cargo test` 通过
- [x] `cargo clippy --all-targets` 零警告
- [x] 每个提交已 DCO 签署（`git commit -s`，见 CONTRIBUTING.md）
- [x] 遵循 Conventional Commits 提交规范
- [x] 视觉改动已附截图（如适用）
 <img width="2369" height="635" alt="image" src="https://github.com/user-attachments/assets/4a64b696-1cde-45be-8a13-ca2a7e590acb" />
